### PR TITLE
Support launching albumbler from init script daemons

### DIFF
--- a/albumbler
+++ b/albumbler
@@ -7,6 +7,7 @@ import subprocess, os, random, time, sys, ConfigParser, socket
 import cPickle as pickle
 
 # defaults
+global_config_root = '/etc/albumbler/'
 conf = {
     'music_paths': [os.getenv('HOME')],
     'time_window': 60.0,
@@ -35,18 +36,35 @@ Anything less than time_window is considered as skipped.
 # tapered dislike between 1 minute and 1 hour
 # make some sort of album fingerprinting
 
-def xdg_paths():
+def get_prefix():
     j = os.path.join
     e = os.getenv
-    config = e('XDG_CONFIG_HOME', j(e('HOME'), '.config'))
-    config = j(config, 'albumbler', 'albumbler.config')
-    cache = e('XDG_DATA_HOME', j(e('HOME'), '.local/share'))
-    cache = j(cache, 'albumbler', 'albumbler.pickle')
-    exclude = e('XDG_CONFIG_HOME', j(e('HOME'), '.config'))
-    exclude = j(exclude, 'albumbler', 'excludes')
+    if os.path.exists(global_config_root):
+    	cfg_prefix = global_config_root
+    	cache = j('/var', 'albumbler')
+    elif e('XDG_CONFIG_HOME') and e('XDG_DATA_HOME'):
+        cfg_prefix = j(e('XDG_CONFIG_HOME'), 'albumbler')
+        cache = j(e('XDG_DATA_HOME'), 'albumbler')
+    elif e('HOME') and str(e('HOME')) != '/':
+        cfg_prefix = j(e('HOME'), 'albumbler')
+        cache = e('XDG_DATA_HOME', j(e('HOME'), '.local/share'))
+    else:
+        sys.stderr.write(u"Can't find a suitable configuration file location")
+        return 
+
+    return cfg_prefix, cache
+  
+
+def albumbler_paths(cfg_prefix, cache_prefix):
+    j = os.path.join
+    config = j(cfg_prefix, 'albumbler.config')
+    exclude = j(cfg_prefix, 'excludes')
+    cache = j(cache_prefix, 'albumbler.pickle')
+
     return config, cache, exclude
 
-config_path, cache_path, exclude_path = xdg_paths()  # probably dumb to do this globally
+cfg_prefix, cache_prefix = get_prefix()
+config_path, cache_path, exclude_path = albumbler_paths(cfg_prefix, cache_prefix)  # probably dumb to do this globally
 
 def call(string):
     pipe = subprocess.PIPE


### PR DESCRIPTION
Candidate fix for https://github.com/keenerd/albumbler/issues/5

Option to use /etc/albumbler/albumbler.config and
/var/albumbler/albumbler.pickle to launching from init daemons which
don't have more user friendly environment variables available
